### PR TITLE
:wrench: reconfigure package title: drop @codeo-za prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@codeo-za/vue-burger-menu",
+  "name": "vue-burger-menu",
   "version": "2.1.0",
   "private": false,
   "scripts": {


### PR DESCRIPTION
Prefixes are often used to specify which registry to use - we typically remap usage of packages starting with "@codeo-za/" to be found at github, not npmjs.

We're using this with a github url from within phoenix, identifying it as just `vue-burger-menu`, which causes npm to issue warnings about expired tokens as the package is stored as "@codeo-za/vue-burger-menu" in the package-lock.json, because that's the name presented by the package.json here, even though we're importing it simply as "vue-burger-menu".

One option is to prefix the package in package.json (ie, use dependency "@codeo-za/vue-burger-menu", but the namespacing is not required since we're referring to the package via git+https url, not a version, and would also be confusing to anyone who has seen the "@codeo-za" prefix used for packages which we publish up at GitHub, and we also don't publish this package - we just use it directly from a branch on the repo. Any future work using an @codeo-za/* package from github would also be problematic - there's no advantage to keeping the prefix.

So I've gone with renaming the package to not have the "@codeo-za" prefix, since we're using it directly from an github repo and have no need to namespace the package.

Phoenix refers to this package via the branch "v1.0", so the idea here would be to merge back and create a v1.1 release that I can reference within the phoenix branch where I'm trying to upgrade scss to use the latest (with forwards and uses instead of imports) - so existing clients wouldn't be affected by the rename (the old name still exists in that branch) and new clients can avoid the warning about expired or missing credentials.